### PR TITLE
Add metadata to message event

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -269,6 +269,8 @@ type MessageEvent struct {
 
 	Attachments []slack.Attachment `json:"attachments,omitempty"`
 
+	Metadata *slack.SlackMetadata `json:"metadata,omitempty"`
+
 	// Root is the message that was broadcast to the channel when the SubType is
 	// thread_broadcast. If this is not a thread_broadcast message event, this
 	// value is nil.


### PR DESCRIPTION
In order to read the metadata on received events, we need to add the metadata struct to the MessageEvent